### PR TITLE
Accept any mapnik between 1.4.2 and < 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "xtend": "~3.0.0"
   },
   "peerDependencies": {
-    "mapnik": "~1.4.2"
+    "mapnik": ">= 1.4.2 < 4.0.0"
   },
   "devDependencies": {
     "tap": "~0.4.8",
-    "mapnik": "~1.4.2"
+    "mapnik": ">= 1.4.2 < 4.0.0"
   }
 }


### PR DESCRIPTION
To support node-mapnik 3.x series. Once mapnik 3.x is released we can prob ditch 1.x in this semver.
