### PR TITLE
Added option for synchronous map loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ pool.acquire(function(err, map) {
 ### `fromString(str, initOptions, mapOptions)`
 
 * `str`: a Mapnik XML string
-* `initOptions`: options for initialization. Currently, `size` for map, `bufferSize`. Default `{ size: 256 }`
+* `initOptions`: options for initialization. Currently, `size` for map, `bufferSize`, and `sync` for whether to load map synchronously (may help eliminate race conditions in some situations). Default `{ size: 256, sync: false}`
 * `mapOptions`: options for the `fromString` method.

--- a/index.js
+++ b/index.js
@@ -30,6 +30,26 @@ module.exports = function(mapnik) {
             function destroy(map) {
                 delete map;
             }
+        },
+        fromStringSync: function(xml, initOptions, mapOptions) {
+            var options = xtend({}, defaultOptions, initOptions);
+            mapOptions = mapOptions || {};
+            return Pool({
+                create: create,
+                destroy: destroy,
+                max: N_CPUS
+            });
+            function create(callback) {
+                var map = new mapnik.Map(options.size, options.size);
+                map.fromStringSync(xml, mapOptions);
+                if (options.bufferSize) {
+                    map.bufferSize = options.bufferSize;
+                }
+                return callback(null, map);
+            }
+            function destroy(map) {
+                delete map;
+            }
         }
     };
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var Pool = require('generic-pool').Pool,
     xtend = require('xtend');
 
 var N_CPUS = os.cpus().length,
-    defaultOptions = { size: 256 },
+    defaultOptions = { size: 256, sync: false },
     defaultMapOptions = { };
 
 module.exports = function(mapnik) {
@@ -12,7 +12,7 @@ module.exports = function(mapnik) {
             var options = xtend({}, defaultOptions, initOptions);
             mapOptions = mapOptions || {};
             return Pool({
-                create: create,
+                create: options.sync ? createSync : create,
                 destroy: destroy,
                 max: N_CPUS
             });
@@ -27,19 +27,7 @@ module.exports = function(mapnik) {
                     return callback(err, map);
                 }
             }
-            function destroy(map) {
-                delete map;
-            }
-        },
-        fromStringSync: function(xml, initOptions, mapOptions) {
-            var options = xtend({}, defaultOptions, initOptions);
-            mapOptions = mapOptions || {};
-            return Pool({
-                create: create,
-                destroy: destroy,
-                max: N_CPUS
-            });
-            function create(callback) {
+            function createSync(callback) {
                 var map = new mapnik.Map(options.size, options.size);
                 map.fromStringSync(xml, mapOptions);
                 if (options.bufferSize) {

--- a/index.js
+++ b/index.js
@@ -29,7 +29,12 @@ module.exports = function(mapnik) {
             }
             function createSync(callback) {
                 var map = new mapnik.Map(options.size, options.size);
-                map.fromStringSync(xml, mapOptions);
+                try {
+                  map.fromStringSync(xml, mapOptions);
+                }
+                catch (err) {
+                  return callback(err);
+                }
                 if (options.bufferSize) {
                     map.bufferSize = options.bufferSize;
                 }

--- a/test/pool.js
+++ b/test/pool.js
@@ -64,3 +64,39 @@ test('passes errors', function(t) {
         });
     });
 });
+
+test('mapnik-pool synchronous loading', function(t) {
+    var pool = mapnikPool.fromString(
+            fs.readFileSync(__dirname + '/data/map.xml', 'utf8'),
+            { bufferSize: 256, sync: true});
+
+    pool.acquire(function(err, map) {
+        t.equal(err, null, 'no error returned');
+        t.pass('acquires a map');
+        t.equal(map.bufferSize, 256, 'sets a buffer size');
+        t.equal(map.width, 256, 'sets map size');
+        t.equal(map.height, 256, 'sets map size');
+        pool.release(map);
+        pool.drain(function() {
+            pool.destroyAllNow(function() {
+                t.end();
+            });
+        });
+    });
+});
+
+test('synchronous loading passes errors', function(t) {
+    var pool = mapnikPool.fromString('invalid map',
+            { bufferSize: 256, sync: true });
+
+    pool.acquire(function(err, map) {
+        t.ok(err instanceof Error,'expected error');
+        t.ok(!map,'expected map to be null');
+        pool.drain(function() {
+            pool.destroyAllNow(function() {
+                t.end();
+            });
+        });
+    });
+});
+


### PR DESCRIPTION
In creating a module to be run in an Electron render thread, I was running into an apparent race condition with creating many pooled instances simultaneously on load (the issue seems similar to that in mapnik/mapnik#1459).

I was able to solve the issue by synchronously loading mapfiles using the `map.fromStringSync` method. Here, I've added this as an option (disabled by default) for mapnik-pool. I've added some tests and it appears that everything works well. There are no changes to the API except a boolean `sync` flag in `initOptions`.