### PR TITLE
Semver fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "xtend": "~4.0.0"
   },
   "peerDependencies": {
-    "mapnik": ">= 1.4.2 && < 4.0.0"
+    "mapnik": "*"
   },
   "devDependencies": {
     "coveralls": "^2.11.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "xtend": "~4.0.0"
   },
   "peerDependencies": {
-    "mapnik": "*"
+    "mapnik": "~3.4.16"
   },
   "devDependencies": {
     "coveralls": "^2.11.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "xtend": "~4.0.0"
   },
   "peerDependencies": {
-    "mapnik": ">= 1.4.2 < 4.0.0"
+    "mapnik": ">= 1.4.2 && < 4.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.4",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "generic-pool": "~2.2.1",
     "xtend": "~4.0.0"
   },
-  "peerDependencies": {
-    "mapnik": "~3.4.16"
-  },
   "devDependencies": {
     "coveralls": "^2.11.4",
     "istanbul": "^0.4.0",


### PR DESCRIPTION
Removes the use of peerDepedencies. This breaks in node v0.12.x with:

```
npm WARN peerDependencies The peer dependency mapnik@>= 1.4.2 < 4.0.0 included from mapnik-pool will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
> mapnik@3.4.16-v2 install /home/travis/build/mapbox/tilelive-bridge/node_modules/mapnik
> node-pre-gyp install --fallback-to-build
[mapnik] Success: "/home/travis/build/mapbox/tilelive-bridge/node_modules/mapnik/lib/binding/node-v14-linux-x64/mapnik.node" is installed via remote
npm ERR! Linux 3.13.0-40-generic
npm ERR! argv "/home/travis/.nvm/versions/node/v0.12.9/bin/node" "/home/travis/.nvm/versions/node/v0.12.9/bin/npm" "install"
npm ERR! node v0.12.9
npm ERR! npm  v2.14.9
npm ERR! code EPEERINVALID
npm ERR! peerinvalid The package mapnik@3.4.16-v2 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer mapnik-pool@0.1.2 wants mapnik@>= 1.4.2 < 4.0.0

```