### PR TITLE
add the ability to create map pool from the array of layers #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pool.acquire(function(err, map) {
 * `initOptions`: options for initialization. Currently, `size` for map, `bufferSize`. Default `{ size: 256 }`
 * `mapOptions`: options for the `fromString` method.
 
-### `fromLayers(arr, initOptions, mapOptions)`
+### `fromLayers(arr, initOptions)`
 
 * `arr`: an array of Mapnik layers
 * `initOptions`: options for initialization. Currently, `srs`, `size` for map, `bufferSize`. Default `{ size: 256 }`

--- a/README.md
+++ b/README.md
@@ -27,6 +27,24 @@ var pool = mapnikPool.fromString(fs.readFileSync('mymap.xml', 'utf8'));
 
 pool.acquire(function(err, map) {
     // pooled map
+    pool.release(map);
+});
+```
+
+```js
+var mapnik = require('mapnik'),
+    mapnikPool = require('mapnik-pool')(mapnik),
+    fs = require('fs');
+
+var datasource = new mapnik.Datasource(...);
+var layer = new mapnik.Layer(...);
+layer.datasource = datasource;
+
+var pool = mapnikPool.fromLayers([layer], { size: 256, srs: '...' });
+
+pool.acquire(function(err, map) {
+    // pooled map
+    pool.release(map);
 });
 ```
 
@@ -37,3 +55,8 @@ pool.acquire(function(err, map) {
 * `str`: a Mapnik XML string
 * `initOptions`: options for initialization. Currently, `size` for map, `bufferSize`. Default `{ size: 256 }`
 * `mapOptions`: options for the `fromString` method.
+
+### `fromLayers(arr, initOptions, mapOptions)`
+
+* `arr`: an array of Mapnik layers
+* `initOptions`: options for initialization. Currently, `srs`, `size` for map, `bufferSize`. Default `{ size: 256 }`

--- a/index.js
+++ b/index.js
@@ -40,7 +40,9 @@ module.exports = function(mapnik) {
             });
             function create(callback) {
                 var map = new mapnik.Map(options.size, options.size, options.srs);
-                layers.forEach(layer => map.add_layer(layer));
+                for (var i = 0; i < layers.length; i++) {
+                    map.add_layer(layers[i]);
+                }
                 if (options.bufferSize) {
                     map.bufferSize = options.bufferSize;
                 }

--- a/index.js
+++ b/index.js
@@ -30,6 +30,25 @@ module.exports = function(mapnik) {
             function destroy(map) {
                 delete map;
             }
+        },
+        fromLayers: function(layers, initOptions) {
+            var options = xtend({}, defaultOptions, initOptions);
+            return Pool({
+                create: create,
+                destroy: destroy,
+                max: N_CPUS
+            });
+            function create(callback) {
+                var map = new mapnik.Map(options.size, options.size, options.srs);
+                layers.forEach(layer => map.add_layer(layer));
+                if (options.bufferSize) {
+                    map.bufferSize = options.bufferSize;
+                }
+                return callback(null, map);
+            }
+            function destroy(map) {
+                delete map;
+            }
         }
     };
 };


### PR DESCRIPTION
This PR will add `fromLayers(arr, initOptions)` method, wich allows to create map pool from array of Mapnik Layers like this:

```js
var mapnik = require('mapnik'),
    mapnikPool = require('mapnik-pool')(mapnik),
    fs = require('fs');

var datasource = new mapnik.Datasource(...);
var layer = new mapnik.Layer(...);
layer.datasource = datasource;

var pool = mapnikPool.fromLayers([layer], { size: 256, srs: '...' });

pool.acquire(function(err, map) {
    // pooled map
    pool.release(map);
});
```

See #12 for issue.